### PR TITLE
Enable rewrite at vhost level

### DIFF
--- a/ols1clk.sh
+++ b/ols1clk.sh
@@ -959,8 +959,12 @@ context / {
     enable                1
     inherit               1
     rewriteFile           $WORDPRESSPATH/.htaccess
-
   }
+}
+
+rewrite  {
+  enable                  1
+  autoLoadHtaccess        1
 }
 
 END


### PR DESCRIPTION
Without this change, URLs look like this: /index.php/hello-world/ , no matter what you change in wordpress and htaccess.

Chanding the below flag in OLS panel, generates the code from the PR

![image](https://user-images.githubusercontent.com/894306/79002300-d8a12780-7b58-11ea-92fa-de1bd06ae5a0.png)
