### PR TITLE
Fix password file output to cope with custom webadmin usernames

### DIFF
--- a/ols1clk.sh
+++ b/ols1clk.sh
@@ -698,7 +698,7 @@ function main_gen_password
 
 function main_ols_password
 {
-    echo "WebAdmin username is [admin], password is [$ADMINPASSWORD]." >> ${PWD_FILE}
+    echo "WebAdmin username is [$ADMINUSER], password is [$ADMINPASSWORD]." >> ${PWD_FILE}
     set_ols_password
 }
 


### PR DESCRIPTION
#61 introduced the ability to set a custom admin username

The password file output (to $SERVER_ROOT/password) containing all of your various credentials that have been created was still using a fixed username string of "admin" instead of the variable.